### PR TITLE
Change label to "Restore Old Annotations"

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -275,7 +275,7 @@ waitForElement(".ytp-panel-menu").then(el => {
 	annoSwitchPar.className = "ytp-menuitem";
 	annoSwitchPar.innerHTML = `
 	<div class="ytp-menuitem-icon"></div>
-	<div class="ytp-menuitem-label">Restore Annotations</div>
+	<div class="ytp-menuitem-label">Restore Old Annotations</div>
 	<div class="ytp-menuitem-content">
 		<div class="ytp-menuitem-toggle-checkbox">
 		<input type="checkbox" id="annotation-sneaky-switch" aria-hidden="true" style="position: absolute; left: -100vw;">


### PR DESCRIPTION
I think this would be better wording on the label to help differentiate between the other "Annotations" button.
![image](https://user-images.githubusercontent.com/31359599/221381589-dcc5b0ab-6034-4044-9e08-04851fc2c66c.png)
