### PR TITLE
Add Turkish translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ There are also a few issues marked as `help wanted` [here](https://github.com/is
 
 - Brazilian Portuguese added by [@Gersonzao](https://github.com/Gersonzao)
 - Polish added by Kamil K
+- Turkish added by [@arda-guler](https://github.com/arda-guler)
 
 Currently, all other translations in the extension are done by Google Translate and may be inaccurate. Pull requests fixing any incorrect translations or adding new ones are appreciated! The relevant files can be found in the `_locales` directory.
 

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -1,0 +1,77 @@
+{
+	"name": {
+		"message": "YouTube™ için Ek Açıklama Kurtarıcı"
+	},
+	"shortName": {
+		"message": "Ek Açıklama Kurtarıcı"
+	},
+	"description": {
+		"message": "YouTube™'a ek açıklama desteğini geri getirin!"
+	},
+
+	"statusTextNoVideo": {
+		"message": "Oynayan video yok."
+	},
+	"statusTextCheckingForVideo": {
+		"message": "Ek açıklamalar kontrol ediliyor..."
+	},
+
+	"loadAnnotationText": {
+		"message": "Ek Açıklama Dosyası Yükle"
+	},
+	"manageCacheText": {
+		"message": "Cache'i Düzenle"
+	},
+
+	"annotationCountSingular": {
+		"message": "Ek Açıklama"
+	},
+	"annotationCountPlural": {
+		"message": "Ek Açıklama"
+	},
+
+	"annotationTableType": {
+		"message": "Tip"
+	},
+	"annotationTableText": {
+		"message": "Metin"
+	},
+	"annotationTableTime": {
+		"message": "Zaman"
+	},
+
+	"annotationNoText": {
+		"message": "Metin yok"
+	},
+
+	"downloadButtonText": {
+		"message": "İndir"
+	},
+
+	"missingAnnotationsHeader": {
+		"message": "Hmm. Bu video için herhangi bir ek açıklama yok gibi görünüyor."
+	},
+	"missingAnnotationsText1": {
+		"message": "Ek açıklama dosyanız mı var?"
+	},
+	"missingAnnotationsText2": {
+		"message": "Şu e-posta adresine gönderin: "
+	},
+
+	"donateButtonText": {
+		"message": "Bana bir kahve alın!"
+	},
+
+	"manageCacheHeader": {
+		"message": "Ek Açıklama Kurtarıcı Cache'ini Düzenle"
+	},
+	"manageCacheTotalSizeText": {
+		"message": "Toplam Boyut:"
+	},
+	"manageCacheOpenButtonText": {
+		"message": "Aç"
+	},
+	"manageCacheDeleteButtonText": {
+		"message": "Sil"
+	}
+}


### PR DESCRIPTION
...as stated in the title.

As "Annotations Restored" actually translates to sth like "Restore Edilmiş Ek Açıklamalar" which is a mouthful, I went with the shorter equivalent which is more like "Annotation Recoverer". Oh, I'm just nitpicking my work.

Bottom line, I might have to come up with something better if one day we get the functionality to add new annotations. Until then it will work, because for god's sake, I can't come up with a shorter translation for the name :D

Also, I wrote the same thing for the singular and plural versions of the word "annotation" for the annotation count text, because we use the singular version no matter if the number is 1 or larger, so it is not a typo.

Thank you for the lovely project, really appreciated!